### PR TITLE
Add minimal EDA agent extension

### DIFF
--- a/packages/eda-agent/README.md
+++ b/packages/eda-agent/README.md
@@ -1,0 +1,5 @@
+# @jupyterlab/eda-agent
+
+A minimal JupyterLab extension that adds an "EDA Agent" side panel and a
+"Start Agent" toolbar button to notebooks. Clicking the button logs
+"Agent Started" to the browser console.

--- a/packages/eda-agent/package.json
+++ b/packages/eda-agent/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@jupyterlab/eda-agent",
+  "version": "0.1.0",
+  "description": "Minimal EDA Agent extension",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "extension"
+  ],
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
+  "sideEffects": [
+    "style/*.css"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "style": "style/index.css",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib/*.{d.ts,js,js.map}",
+    "style/*.css",
+    "src/**/*.ts"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "watch": "tsc -b --watch"
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^4.5.0-alpha.3",
+    "@jupyterlab/apputils": "^4.6.0-alpha.3",
+    "@jupyterlab/docregistry": "^4.5.0-alpha.3",
+    "@jupyterlab/notebook": "^4.5.0-alpha.3",
+    "@lumino/widgets": "^2.7.1"
+  },
+  "devDependencies": {
+    "rimraf": "~5.0.5",
+    "typescript": "~5.5.4"
+  },
+  "jupyterlab": {
+    "extension": true
+  }
+}

--- a/packages/eda-agent/src/index.ts
+++ b/packages/eda-agent/src/index.ts
@@ -1,0 +1,54 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { INotebookModel, INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
+import { ToolbarButton } from '@jupyterlab/apputils';
+import { Widget } from '@lumino/widgets';
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { DisposableDelegate, IDisposable } from '@lumino/disposable';
+
+/**
+ * A widget extension that adds a Start Agent button to the notebook toolbar.
+ */
+class StartButtonExtension implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+  createNew(panel: NotebookPanel, context: DocumentRegistry.IContext<INotebookModel>): IDisposable {
+    const button = new ToolbarButton({
+      label: 'Start Agent',
+      onClick: () => {
+        console.log('Agent Started');
+      },
+      tooltip: 'Start Agent'
+    });
+    panel.toolbar.insertItem(0, 'startAgent', button);
+    return new DisposableDelegate(() => {
+      button.dispose();
+    });
+  }
+}
+
+/**
+ * Initialization data for the eda-agent extension.
+ */
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/eda-agent:plugin',
+  autoStart: true,
+  requires: [INotebookTracker],
+  activate: (app: JupyterFrontEnd, tracker: INotebookTracker) => {
+    console.log('JupyterLab extension eda-agent is activated!');
+
+    // Create and add the side panel
+    const content = new Widget();
+    content.id = 'eda-agent-panel';
+    content.title.label = 'EDA Agent';
+    content.title.closable = true;
+    content.addClass('jp-EDAAgentPanel');
+    app.shell.add(content, 'left', { rank: 900 });
+
+    // Add the notebook toolbar button
+    app.docRegistry.addWidgetExtension('Notebook', new StartButtonExtension());
+  }
+};
+
+export default plugin;

--- a/packages/eda-agent/style/index.css
+++ b/packages/eda-agent/style/index.css
@@ -1,0 +1,3 @@
+.jp-EDAAgentPanel {
+  padding: 8px;
+}

--- a/packages/eda-agent/tsconfig.json
+++ b/packages/eda-agent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfigbase",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/*"],
+  "references": [
+    { "path": "../application" },
+    { "path": "../apputils" },
+    { "path": "../notebook" },
+    { "path": "../docregistry" }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,6 +3094,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@jupyterlab/eda-agent@workspace:packages/eda-agent":
+  version: 0.0.0-use.local
+  resolution: "@jupyterlab/eda-agent@workspace:packages/eda-agent"
+  dependencies:
+    "@jupyterlab/application": ^4.5.0-alpha.3
+    "@jupyterlab/apputils": ^4.6.0-alpha.3
+    "@jupyterlab/docregistry": ^4.5.0-alpha.3
+    "@jupyterlab/notebook": ^4.5.0-alpha.3
+    "@lumino/widgets": ^2.7.1
+    rimraf: ~5.0.5
+    typescript: ~5.5.4
+  languageName: unknown
+  linkType: soft
+
 "@jupyterlab/example-app@workspace:examples/app":
   version: 0.0.0-use.local
   resolution: "@jupyterlab/example-app@workspace:examples/app"


### PR DESCRIPTION
## Summary
- add `@jupyterlab/eda-agent` extension package
- register side panel and notebook toolbar button
- log a message when the button is clicked

## Testing
- `yarn install`
- `yarn build` (packages/eda-agent)
- `yarn eslint packages/eda-agent/src/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ba0c2f3e808324bfdd562957a02784