### PR TITLE
feat(eda-agent): add chat panel

### DIFF
--- a/packages/eda-agent/package.json
+++ b/packages/eda-agent/package.json
@@ -29,7 +29,7 @@
   "files": [
     "lib/*.{d.ts,js,js.map}",
     "style/*.css",
-    "src/**/*.ts"
+    "src/**/*.{ts,tsx}"
   ],
   "scripts": {
     "build": "tsc -b",

--- a/packages/eda-agent/src/chat-panel.tsx
+++ b/packages/eda-agent/src/chat-panel.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { ReactWidget } from '@jupyterlab/apputils';
+
+/**
+ * A simple chat panel using React.
+ */
+export class ChatPanel extends ReactWidget {
+  constructor() {
+    super();
+    this.addClass('jp-EDAAgentChatPanel');
+  }
+
+  protected render(): JSX.Element {
+    return <ChatComponent />;
+  }
+}
+
+const ChatComponent = (): JSX.Element => {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const handleSend = (): void => {
+    if (!input.trim()) {
+      return;
+    }
+    setMessages([...messages, input]);
+    setInput('');
+  };
+
+  return (
+    <div className="jp-EDAAgentChatContainer">
+      <div className="jp-EDAAgentChatMessages">
+        {messages.map((m, i) => (
+          <div key={i} className="jp-EDAAgentChatMessage">
+            {m}
+          </div>
+        ))}
+      </div>
+      <div className="jp-EDAAgentChatInput">
+        <input
+          className="jp-EDAAgentInputField"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              handleSend();
+            }
+          }}
+        />
+        <button className="jp-EDAAgentSendButton" onClick={handleSend}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ChatPanel;

--- a/packages/eda-agent/src/index.ts
+++ b/packages/eda-agent/src/index.ts
@@ -3,17 +3,26 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { INotebookModel, INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
+import {
+  INotebookModel,
+  INotebookTracker,
+  NotebookPanel
+} from '@jupyterlab/notebook';
 import { ToolbarButton } from '@jupyterlab/apputils';
-import { Widget } from '@lumino/widgets';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { DisposableDelegate, IDisposable } from '@lumino/disposable';
+import { ChatPanel } from './chat-panel';
 
 /**
  * A widget extension that adds a Start Agent button to the notebook toolbar.
  */
-class StartButtonExtension implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
-  createNew(panel: NotebookPanel, context: DocumentRegistry.IContext<INotebookModel>): IDisposable {
+class StartButtonExtension
+  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>
+{
+  createNew(
+    panel: NotebookPanel,
+    context: DocumentRegistry.IContext<INotebookModel>
+  ): IDisposable {
     const button = new ToolbarButton({
       label: 'Start Agent',
       onClick: () => {
@@ -35,16 +44,30 @@ const plugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/eda-agent:plugin',
   autoStart: true,
   requires: [INotebookTracker],
-  activate: (app: JupyterFrontEnd, tracker: INotebookTracker) => {
+  activate: (app: JupyterFrontEnd, _tracker: INotebookTracker) => {
     console.log('JupyterLab extension eda-agent is activated!');
 
-    // Create and add the side panel
-    const content = new Widget();
-    content.id = 'eda-agent-panel';
-    content.title.label = 'EDA Agent';
-    content.title.closable = true;
-    content.addClass('jp-EDAAgentPanel');
-    app.shell.add(content, 'left', { rank: 900 });
+    // Create and add the chat panel
+    const chatPanel = new ChatPanel();
+    chatPanel.id = 'eda-agent-chat-panel';
+    chatPanel.title.label = 'EDA Chat';
+    chatPanel.title.closable = true;
+    app.shell.add(chatPanel, 'right');
+
+    // Command to toggle the chat panel visibility
+    app.commands.addCommand('eda-agent:toggle-chat', {
+      label: 'Toggle EDA Chat',
+      execute: () => {
+        if (!chatPanel.isAttached) {
+          app.shell.add(chatPanel, 'right');
+        } else if (chatPanel.isHidden) {
+          chatPanel.show();
+          app.shell.activateById(chatPanel.id);
+        } else {
+          chatPanel.hide();
+        }
+      }
+    });
 
     // Add the notebook toolbar button
     app.docRegistry.addWidgetExtension('Notebook', new StartButtonExtension());


### PR DESCRIPTION
## Summary
- add React-based chat panel for EDA agent
- register panel on right side and add toggle command
- include tsx sources in package

## Testing
- `npx prettier packages/eda-agent/src/index.ts packages/eda-agent/src/chat-panel.tsx packages/eda-agent/package.json --write`
- `npx eslint packages/eda-agent/src/index.ts packages/eda-agent/src/chat-panel.tsx`
- `npx tsc -b packages/eda-agent/tsconfig.json`
- `npx lerna run test --scope @jupyterlab/eda-agent`


------
https://chatgpt.com/codex/tasks/task_e_68ba5e048dc88324b48318286f0ac9c1